### PR TITLE
Update tracking link styles

### DIFF
--- a/src/components/events/events.jsx
+++ b/src/components/events/events.jsx
@@ -45,6 +45,36 @@ const defaultProps = {
 };
 
 function Events({ labels, noResults }) {
+  const trackingLink = (label) => {
+    const linkInfo = getTrackingLink(label.carrier, label.carrier_tracking_number);
+
+    if (linkInfo) {
+      return (
+        <div className={bem.element('tracking-link')}>
+          <a
+            className={bem.element('tracking-link-a-icon')}
+            href={linkInfo.url}
+            target="_blank"
+            rel="noopener noreferrer">
+            <Icon
+              className={bem.element('tracking-link-icon')}
+              name="icon-arrow-right" />
+          </a>
+
+          <a
+            className={bem.element('tracking-link-a-text')}
+            href={linkInfo.url}
+            target="_blank"
+            rel="noopener noreferrer">
+            {linkInfo.text}
+          </a>
+        </div>
+      );
+    }
+
+    return label.carrier_tracking_number;
+  };
+
   return (
     <section className={bem.block()}>
       {labels.map((label, labelIndex) =>
@@ -52,39 +82,9 @@ function Events({ labels, noResults }) {
         <div className={bem.element('label')} key={labelIndex}>
           <section
             className={bem.element('carrier-info', { first: labelIndex === 0 })} key={labelIndex}>
-            <div className={bem.element('carrier')}>Carrier: {label.carrier}</div>
             <div className={bem.element('tracking-number')}>
-              Tracking #: {label.carrier_tracking_number}
+              {label.carrier} Tracking #:&nbsp;{trackingLink(label)}
             </div>
-            {(() => {
-              const linkInfo = getTrackingLink(label.carrier, label.carrier_tracking_number);
-
-              if (linkInfo) {
-                return (
-                  <div className={bem.element('tracking-link')}>
-                    <a
-                      className={bem.element('tracking-link-a-icon')}
-                      href={linkInfo.url}
-                      target="_blank"
-                      rel="noopener noreferrer">
-                      <Icon
-                        className={bem.element('tracking-link-icon')}
-                        name="icon-arrow-right" />
-                    </a>
-
-                    <a
-                      className={bem.element('tracking-link-a-text')}
-                      href={linkInfo.url}
-                      target="_blank"
-                      rel="noopener noreferrer">
-                      {linkInfo.text}
-                    </a>
-                  </div>
-                );
-              }
-
-              return null;
-            })()}
           </section>
           {label.eventGroups.map((events, groupIndex) => {
             const dayFormat = new DateFormat(events[0].timestamp);

--- a/src/components/events/styles.css
+++ b/src/components/events/styles.css
@@ -5,11 +5,16 @@
 
   a:link, a:active, a:visited, a:hover {
     color: #808080;
-    text-decoration: none;
+    text-decoration: underline;;
   }
 
   &__carrier-info--first {
     color: #0051b2;
+
+    & a:link, a:active, a:visited, a:hover {
+      color: var(--flow-blue);
+      text-decoration: underline;;
+    }
   }
 
   &__event-group {
@@ -180,7 +185,7 @@
     }
 
     &__tracking-link {
-      font-size: 1rem;
+      font-size: 1.125rem;
       padding-right: 1.25rem;
     }
 

--- a/src/utilities/tracking-link.js
+++ b/src/utilities/tracking-link.js
@@ -3,27 +3,27 @@ export default function (carrier, number) {
   case 'asendia':
     return {
       url: `http://tracking.asendiausa.com/t.aspx?p=${number}`,
-      text: 'View on Asendia.com',
+      text: number,
     };
   case 'dhl':
     return {
       url: `http://www.dhl.com/en/express/tracking.html?AWB=${number}&brand=DHL`,
-      text: 'View on DHL.com',
+      text: number,
     };
   case 'landmark':
     return {
       url: `https://mercury.landmarkglobal.com/tracking/track.php?trck=${number}&Submit=Track`,
-      text: 'View on Landmarkglobal.com',
+      text: number,
     };
   case 'ups':
     return {
       url: `https://wwwapps.ups.com/tracking/tracking.cgi?tracknum=${number}`,
-      text: 'View on UPS.com',
+      text: number,
     };
   case 'usps':
     return {
       url: `https://tools.usps.com/go/TrackConfirmAction?qtc_tLabels1=${number}`,
-      text: 'View on USPS.com',
+      text: number,
     };
   default:
     return undefined;


### PR DESCRIPTION
- Made the tracking number visually clickable
- Remove “carrier:” before carrier name
- Remove the view on xxxx text button

![screen shot 2017-01-11 at 2 42 17 pm](https://cloud.githubusercontent.com/assets/882208/21863650/52b419d6-d80c-11e6-8d61-ccd18e9c8e76.png)
