### PR TITLE
FDN-3768:Correcting pipeline by proving permission for npm-run-all

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,6 +92,7 @@ pipeline {
                 npm --version
                 echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
                 #sleep 1800
+                chmod +x node_modules/.bin/npm-run-all
                 npm install && npm prune
                 npm run build
                 mv dist/js/main.css dist/css/main.css


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/104558bf-7757-43aa-986c-5ca411771a2a)
