### PR TITLE
FDN-4552: use generic pod template instead of kaniko-slim

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
   
   agent {
     kubernetes {
-      inheritFrom 'kaniko-slim'
+      inheritFrom 'generic'
 
       containerTemplates([
         containerTemplate(name: 'nodejs', image: "479720515435.dkr.ecr.us-east-1.amazonaws.com/flowcommerce/node16_builder:latest", resourceRequestCpu: '1', resourceRequestMemory: '4Gi', command: 'cat', ttyEnabled: true, runAsUser: '1000'),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
       inheritFrom 'generic'
 
       containerTemplates([
-        containerTemplate(name: 'nodejs', image: "479720515435.dkr.ecr.us-east-1.amazonaws.com/flowcommerce/node16_builder:latest", resourceRequestCpu: '1', resourceRequestMemory: '4Gi', command: 'cat', ttyEnabled: true, runAsUser: '1000'),
+        containerTemplate(name: 'nodejs', image: "479720515435.dkr.ecr.us-east-1.amazonaws.com/flowcommerce/node18_builder:latest", resourceRequestCpu: '1', resourceRequestMemory: '4Gi', command: 'cat', ttyEnabled: true, runAsUser: '1000'),
       ])
     }
   }


### PR DESCRIPTION
No containers from the kaniko-slim template (kaniko, helm, helm3) are
used by this repo. Migrating to generic eliminates the idle kaniko
container that was being scheduled on every build.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js builder to a newer version
  * Adjusted container pod configuration for enhanced build environment compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->